### PR TITLE
Reverse proxy + Debian Wheezy backport repository

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Ensure Debian Wheezy backport repository is added (to get HAProxy).
+  apt_repository: repo='deb http://ftp.debian.org/debian wheezy-backports main' state=present
+  when: ansible_distribution_release == 'wheezy'
+
 - name: Ensure HAProxy is installed (Debian).
   apt: name=haproxy state=installed
   when: ansible_os_family == 'Debian'

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -1,51 +1,67 @@
 global
-  log /dev/log  local0
-  log /dev/log  local1 notice
+	log	/dev/log	local0
+	log /dev/log	local1 notice
 {% if haproxy_socket != '' %}
-  stats socket {{ haproxy_socket }} level admin
+	stats socket {{ haproxy_socket }} mode 660 level admin
 {% endif %}
 {% if haproxy_chroot != '' %}
-  chroot {{ haproxy_chroot }}
+	chroot {{ haproxy_chroot }}
 {% endif %}
-  user {{ haproxy_user }}
-  group {{ haproxy_group }}
-  daemon
+	user {{ haproxy_user }}
+	group {{ haproxy_group }}
+	daemon
 
 defaults
-  log global
-  mode  http
-  option  httplog
-  option  dontlognull
+	log global
+	mode  http
+	option  httplog
+	option  dontlognull
 {% if haproxy_version == '1.4' %}
-        contimeout 5000
-        clitimeout 50000
-        srvtimeout 50000
+		contimeout 5000
+		clitimeout 50000
+		srvtimeout 50000
 {% else %}
-        timeout connect 5000
-        timeout client 50000
-        timeout server 50000
+		timeout connect 5000
+		timeout client 50000
+		timeout server 50000
 {% endif %}
 {% if ansible_os_family == 'Debian' %}
-  errorfile 400 /etc/haproxy/errors/400.http
-  errorfile 403 /etc/haproxy/errors/403.http
-  errorfile 408 /etc/haproxy/errors/408.http
-  errorfile 500 /etc/haproxy/errors/500.http
-  errorfile 502 /etc/haproxy/errors/502.http
-  errorfile 503 /etc/haproxy/errors/503.http
-  errorfile 504 /etc/haproxy/errors/504.http
+	errorfile 400 /etc/haproxy/errors/400.http
+	errorfile 403 /etc/haproxy/errors/403.http
+	errorfile 408 /etc/haproxy/errors/408.http
+	errorfile 500 /etc/haproxy/errors/500.http
+	errorfile 502 /etc/haproxy/errors/502.http
+	errorfile 503 /etc/haproxy/errors/503.http
+	errorfile 504 /etc/haproxy/errors/504.http
 {% endif %}
 
 frontend {{ haproxy_frontend_name }}
-    bind {{ haproxy_frontend_bind_address }}:{{ haproxy_frontend_port }}
-    mode {{ haproxy_frontend_mode }}
-    default_backend {{ haproxy_backend_name }}
+	bind {{ haproxy_frontend_bind_address }}:{{ haproxy_frontend_port }}
+{% for acl in haproxy_frontend_acls %}
+	{{ acl }}
+{% endfor %}
+{% for acl_match in haproxy_frontend_acl_matches %}
+	{{ acl_match }}
+{% endfor %}
 
-backend {{ haproxy_backend_name }}
-    mode {{ haproxy_backend_mode }}
-    balance {{ haproxy_backend_balance_method }}
-    option forwardfor
-    option httpchk {{ haproxy_backend_httpchk }}
-    cookie SERVERID insert indirect
-{% for backend in haproxy_backend_servers %}
-    server {{ backend.name }} {{ backend.address }} cookie {{ backend.name }} check
+{% if haproxy_default_backend_name is defined %}
+	default_backend {{ haproxy_default_backend_name }}
+{% endif %}
+
+
+{% for backend in haproxy_backends %}
+backend {{ backend.name }}
+	mode {{ backend.mode }}
+{% if backend.balance_method is defined %}
+	balance {{ backend.balance_method }}
+{% endif %}
+	option forwardfor
+	cookie SERVERID insert indirect
+	{% if backend.httpchk is defined %}
+	option httpchk {{ backend.httpchk }}
+	{% endif %}
+{% for server in backend.servers %}
+	server {{ server.name }} {{ server.address }} cookie {{ server.name }} check
+{% endfor %}
+
 {% endfor %}


### PR DESCRIPTION
Added ACLs for reverse proxy with multiple backends
Debian wheezy support by adding backport repository, which provides the package

example variable file: 

```
haprox_user: 'haproxy'
haproxy_group: 'haproxy'

haproxy_chroot: '/var/lib/haproxy'
haproxy_socket: '/run/haproxy/admin.sock'
haproxy_frontend_name: 'http-in'
haproxy_frontend_bind_address: '*'
haproxy_frontend_port: 80
haproxy_frontend_mode: 'http'
haproxy_frontend_acls:
  - 'acl host_back_dev hdr(host) -i back.foobar-dev.net'
  - 'acl host_front_dev hdr(host) -i front.foobar-dev.net'

  - 'acl host_back_preprod hdr(host) -i back.foobar-preprod.net'
  - 'acl host_front_preprod hdr(host) -i front.foobar-preprod.net'

  - 'acl host_back_prod hdr(host) -i back.foobar-prod.net'
  - 'acl host_front_prod hdr(host) -i front.foobar-prod.net'

haproxy_frontend_acl_matches:
  - 'use_backend dev_cluster if host_back_dev'
  - 'use_backend dev_cluster if host_front_dev'

  - 'use_backend preprod_cluster if host_back_preprod'
  - 'use_backend preprod_cluster if host_front_preprod'

  - 'use_backend prod_cluster if host_back_prod'
  - 'use_backend prod_cluster if host_front_prod'
haproxy_backends:
  - name: 'dev_cluster'
    mode: 'http'
    servers:
      - name: 'server1'
        address: '192.168.12.11:80'

  - name: 'preprod_cluster'
    mode: 'http'
    servers:
      - name: 'server1'
        address: '192.168.12.12:80'

  - name: 'prod_cluster'
    mode: 'http'
    servers:
      - name: 'server1'
        address: '192.168.12.13:80'

```
