### PR TITLE
Validate haproxy.cfg template

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
     src: haproxy.cfg.j2
     dest: /etc/haproxy/haproxy.cfg
     mode: 0644
+    validate: haproxy -f %s -c -q
   notify: restart haproxy
 
 - name: Ensure HAProxy is started and enabled on boot.


### PR DESCRIPTION
This pull request adds the validate command to the haproxy.cfg template task to avoid the following debug session:

A playbook failed with this error:

```
RUNNING HANDLER [geerlingguy.haproxy : restart haproxy] ************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Job for haproxy.service failed because the control process exited with error code. See \"systemctl status h
aproxy.service\" and \"journalctl -xe\" for details.\n"}
```

Systemctl returned this error:

```
# systemctl status haproxy
● haproxy.service - HAProxy Load Balancer
   Loaded: loaded (/lib/systemd/system/haproxy.service; enabled; vendor preset: enabled)
   Active: inactive (dead) (Result: exit-code) since Tue 2016-08-09 22:37:20 UTC; 22min ago
     Docs: man:haproxy(1)
           file:/usr/share/doc/haproxy/configuration.txt.gz
  Process: 24939 ExecStart=/usr/sbin/haproxy-systemd-wrapper -f ${CONFIG} -p /run/haproxy.pid $EXTRAOPTS (code=exited, status=0/SUCCESS)
  Process: 25337 ExecStartPre=/usr/sbin/haproxy -f ${CONFIG} -c -q (code=exited, status=1/FAILURE)
 Main PID: 24939 (code=exited, status=0/SUCCESS)

Aug 09 22:37:20 foobar systemd[1]: Failed to start HAProxy Load Balancer.
Aug 09 22:37:20 foobar systemd[1]: haproxy.service: Unit entered failed state.
Aug 09 22:37:20 foobar systemd[1]: haproxy.service: Failed with result 'exit-code'.
Aug 09 22:37:20 foobar systemd[1]: haproxy.service: Service hold-off time over, scheduling restart.
Aug 09 22:37:20 foobar systemd[1]: Stopped HAProxy Load Balancer.
Aug 09 22:37:20 foobar systemd[1]: haproxy.service: Start request repeated too quickly.
Aug 09 22:37:20 foobar systemd[1]: Failed to start HAProxy Load Balancer.
```

The haproxy.service `ExecStartPre=/usr/sbin/haproxy -f ${CONFIG} -c -q` returned this error:

```
# /usr/sbin/haproxy -c -f /etc/haproxy/haproxy.cfg                                                                                                    
[ALERT] 221/224354 (25378) : parsing [/etc/haproxy/haproxy.cfg:70] : 'appsession' is not supported anymore, please check the documentation.
[ALERT] 221/224354 (25378) : Error(s) found in configuration file : /etc/haproxy/haproxy.cfg
[ALERT] 221/224354 (25378) : Fatal errors found in configuration.
```
