### PR TITLE
Add stats page option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,8 @@ script:
   # Make sure haproxy is installed.
   - 'docker exec --tty ${container_id} env TERM=xterm haproxy -v'
 
+  # Make sure stats page is available and accessible.
+  - 'docker exec --tty ${container_id} env TERM=xterm curl --user user:pass localhost:7777 | grep "Statistics Report"'
+
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ HAProxy backend configuration directives.
 
 A list of backend servers (name and address) to which HAProxy will distribute requests.
 
+    haproxy_stats_enable: false
+    haproxy_stats_port: 7777
+    haproxy_stats_refresh: 30s
+    haproxy_stats_username: ''
+    haproxy_stats_password: ''
+    haproxy_stats_uri: /
+
+HAProxy statistics page configuration directives.
+
     haproxy_global_vars:
       - 'ssl-default-bind-ciphers ABCD+KLMJ:...'
       - 'ssl-default-bind-options no-sslv3'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,11 @@ haproxy_backend_servers: []
 
 # Extra global vars (see README for example usage).
 haproxy_global_vars: []
+
+# Statistics page
+haproxy_stats_enable: false
+haproxy_stats_port: 7777
+haproxy_stats_refresh: 30s
+haproxy_stats_username: ''
+haproxy_stats_password: ''
+haproxy_stats_uri: /

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -54,3 +54,19 @@ backend {{ haproxy_backend_name }}
 {% for backend in haproxy_backend_servers %}
     server {{ backend.name }} {{ backend.address }} cookie {{ backend.name }} check
 {% endfor %}
+
+{% if haproxy_stats_enable %}
+listen stats
+    bind *:{{ haproxy_stats_port }}
+    mode http
+
+    stats enable
+    stats hide-version
+{% if haproxy_stats_refresh != '' %}
+    stats refresh {{ haproxy_stats_refresh }}
+{% endif %}
+{% if haproxy_stats_username != '' %}
+    stats auth {{ haproxy_stats_username }}:{{ haproxy_stats_password }}
+{% endif %}
+    stats uri {{ haproxy_stats_uri }}
+{% endif %}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,6 +6,10 @@
     haproxy_chroot: ''
     haproxy_user: root
     haproxy_group: root
+    haproxy_stats_enable: true
+    haproxy_stats_username: 'user'
+    haproxy_stats_password: 'pass'
+
 
     haproxy_backend_servers:
       - name: app1
@@ -15,6 +19,9 @@
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
+
+    - name: Install dependencies.
+      package: name=curl state=present
 
   roles:
     - role_under_test


### PR DESCRIPTION
See issue #15.
Option to configure stats page for haproxy.

Disabled by default.
Hides HA Proxy version from the stats page.
Possible to set username and password.


I don't have experience running haproxy, what do you think @geerlingguy ?