### PR TITLE
add list of option to the backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ A list of backend servers (name and address) to which HAProxy will distribute re
 
 A list of extra global variables to add to the global configuration section inside `haproxy.cfg`.
 
+A list of backend options. Full list available in [the official documentation](https://www.haproxy.org/download/1.4/doc/configuration.txt)
+
+    haproxy_options:
+        - "mysql-check"
+        # - http_proxy
+        # - redispatch
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,6 @@ haproxy_backend_servers: []
 
 # Extra global vars (see README for example usage).
 haproxy_global_vars: []
+
+# list of backend options (see README for example usage).
+haproxy_options: []

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -51,6 +51,9 @@ backend {{ haproxy_backend_name }}
     option httpchk {{ haproxy_backend_httpchk }}
 {% endif %}
     cookie SERVERID insert indirect
+{% for option in haproxy_options %}
+    option {{ option }}
+{% endfor %}
 {% for backend in haproxy_backend_servers %}
     server {{ backend.name }} {{ backend.address }} cookie {{ backend.name }} check
 {% endfor %}


### PR DESCRIPTION
Allow to add a list of option to the backend like mysql-check. Full list of option [here](https://www.haproxy.org/download/1.4/doc/configuration.txt).