### PR TITLE
Update molecule supported distros used for Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ env:
     - MOLECULE_DISTRO: centos7
       MOLECULE_DOCKER_COMMAND: /usr/lib/systemd/systemd
     - MOLECULE_DISTRO: centos6
+    - MOLECULE_DISTRO: ubuntu1804
     - MOLECULE_DISTRO: ubuntu1604
     - MOLECULE_DISTRO: ubuntu1404
+    - MOLECULE_DISTRO: debian9
 
 install:
   # Install test dependencies.


### PR DESCRIPTION
I'm using this role on the current stable/LTS releases of Debian and Ubuntu and it works very well, also when running molecule everything is good.

So maybe it could be useful for someone else too to include them in the Travis test matrix.

These 2 docker images are already available here:

* https://hub.docker.com/r/geerlingguy/docker-ubuntu1804-ansible/
* https://hub.docker.com/r/geerlingguy/docker-debian9-ansible/

I tried to follow the same logic order for `MOLECULE_DISTRO` vars but please don't hesitate to tell if I need to change something and feel free to accept or reject this PR.

PS: thanks for switch to Molecule https://github.com/geerlingguy/ansible-role-haproxy/commit/f093657e70e53397e670922b5a3fac005e807358!