### PR TITLE
Allow users to use a custom config template

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
+    haproxy_cfg_template: haproxy.cfg.j2
+
+Path to the custom haproxy template. If you put your custom template under the `templates` directory next to your playbook and use a relative path, use a different path than the default one, because ansible, when using relative path, use the first template found and look under the role directory at first then the playbook directory.
+
+### Default template variables
+
     haproxy_socket: /var/lib/haproxy/stats
 
 The socket through which HAProxy can communicate (for admin purposes or statistics). To disable/remove this directive, set `haproxy_socket: ''` (an empty string).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,12 @@ haproxy_chroot: /var/lib/haproxy
 haproxy_user: haproxy
 haproxy_group: haproxy
 
+haproxy_cfg_template: haproxy.cfg.j2
+
+########
+# Haproxy settings used with the default template
+########
+
 # Frontend settings.
 haproxy_frontend_name: 'hafrontend'
 haproxy_frontend_bind_address: '*'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Copy HAProxy configuration in place.
   template:
-    src: haproxy.cfg.j2
+    src: "{{ haproxy_cfg_template }}"
     dest: /etc/haproxy/haproxy.cfg
     mode: 0644
     validate: haproxy -f %s -c -q


### PR DESCRIPTION
It is a following to my [comment](https://github.com/geerlingguy/ansible-role-haproxy/pull/23#issuecomment-450162589) to let easily users to provide custom config.

Config example from [entercloudsuite/ansible-haproxy](https://github.com/entercloudsuite/ansible-haproxy)
Not tested but should be functional, and could eventually had a molecule scenario to be tested if needed

```yaml
$ cat group_vars/haproxy.yaml
---
haproxy_user: admin
haproxy_pass: admin
haproxy_global: |
  global
      log /dev/log local0
      log /dev/log local1 notice
      chroot /var/lib/haproxy
      stats socket /run/haproxy/admin.sock mode 660 level admin
      stats timeout 30s
      user haproxy
      group haproxy
      daemon
      maxconn 200000
      nbproc "{{ ansible_processor_vcpus }}"
  {% for n in range(ansible_processor_vcpus) %}
      cpu-map {{ n + 1 }} {{ n }}
  {% endfor %}
      ca-base /etc/ssl/certs
      crt-base /etc/ssl/private
      ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS:!3DES
      ssl-default-bind-options no-sslv3
      tune.ssl.default-dh-param 2048
haproxy_defaults: |
  defaults
      option log-health-checks
      mode    http
      option  dontlognull
      timeout connect 8000
      timeout client  60000
      timeout server  60000
      errorfile 400 /etc/haproxy/errors/400.http
      errorfile 403 /etc/haproxy/errors/403.http
      errorfile 408 /etc/haproxy/errors/408.http
      errorfile 500 /etc/haproxy/errors/500.http
      errorfile 502 /etc/haproxy/errors/502.http
      errorfile 503 /etc/haproxy/errors/503.http
      errorfile 504 /etc/haproxy/errors/504.http
haproxy_stats: |
  listen stats
      bind *:8282
      mode http
      stats enable
      stats uri /
      stats realm Haproxy\ Statistics
      stats show-desc "HAProxy WebStatistics"
      stats show-node
      stats show-legends
      stats auth {{ haproxy_user }}:{{ haproxy_pass }}
      stats admin if TRUE

haproxy_cert: {}

haproxy_conf: |
  listen web
      mode http
      bind *:80
      default-server port 80
      server web-0 1.1.1.1:80 check

haproxy_confs:
  global: "{{ haproxy_global }}"
  defaults: "{{ haproxy_defaults }}"
  stats: "{{ haproxy_stats }}"
  conf: "{{ haproxy_conf }}"
```

```yaml
$ cat templates/myhaproxy.cfg.j2
{% for key,value in haproxy_confs.items()  %}
{{ value }}
{% endfor %}
```

```yaml
$ cat playbook.yml
- hosts: haproxy
  sudo: yes
  roles:
    - role: geerlingguy.haproxy
      haproxy_cfg_template: myhaproxy.cfg.j2
```

Regards,