### PR TITLE
Support multiple frontends and backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ install:
 before_script:
   # Use actual Ansible Galaxy role name for the project directory.
   - cd ../
-  - mv ansible-role-$ROLE_NAME geerlingguy.$ROLE_NAME
-  - cd geerlingguy.$ROLE_NAME
+  - mv ansible-role-$ROLE_NAME socketwench.$ROLE_NAME
+  - cd socketwench.$ROLE_NAME
 
 script:
   # Run tests.

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ HAProxy backend configuration directives.
 
     haproxy_backend_servers:
       - name: app1
-        address: 192.168.0.1:80
+        address: 192.168.0.1
+        port: 80
       - name: app2
-        address: 192.168.0.2:80
+        address: 192.168.0.2
+        port: 80
 
 A list of backend servers (name and address) to which HAProxy will distribute requests.
 

--- a/README.md
+++ b/README.md
@@ -91,13 +91,17 @@ Likewise, you can also specify multiple backends using `haproxy_backends`:
         mode: 'http'
         servers:
           - name: 'app1'
-            address: '123.123.123.123:80'
-            cookie: yes
-            check: yes
+            address: '123.123.123.123'
+            port: '80'
+            params:
+              - 'cookie'
+              - 'app1'
+              - 'check'
       - name: 'letsencrypt-backend'
         servers:
           - name: 'letsencrypt'
-            address: '127.0.0.1:54321'  
+            address: '127.0.0.1'
+            port: '54321'  
 
 When using `haproxy_backends` all `haproxy_backend_*` variables are ignored.
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 A fork of [geerlingguy.haproxy](https://galaxy.ansible.com/geerlingguy/haproxy), this role installs HAProxy on RedHat/CentOS and Debian/Ubuntu Linux servers. This fork supports multiple frontends, backends, and TLS.
 
-**Note**: This role _officially_ supports HAProxy versions 1.4 or 1.5. Future versions may require some rework.
-
 ## Requirements
 
 None.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Ansible Role: HAProxy
 
-[![Build Status](https://travis-ci.org/geerlingguy/ansible-role-haproxy.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-haproxy)
+[![Build Status](https://travis-ci.org/socketwench/ansible-role-haproxy.svg?branch=master)](https://travis-ci.org/socketwench/ansible-role-haproxy)
 
-Installs HAProxy on RedHat/CentOS and Debian/Ubuntu Linux servers.
+A fork of [geerlingguy.haproxy](https://galaxy.ansible.com/geerlingguy/haproxy), this role installs HAProxy on RedHat/CentOS and Debian/Ubuntu Linux servers. This fork supports multiple frontends, backends, and TLS.
 
 **Note**: This role _officially_ supports HAProxy versions 1.4 or 1.5. Future versions may require some rework.
 
@@ -52,7 +52,7 @@ A list of backend servers (name and address) to which HAProxy will distribute re
     haproxy_global_vars:
       - 'ssl-default-bind-ciphers ABCD+KLMJ:...'
       - 'ssl-default-bind-options no-sslv3'
-      
+
 A list of default options to use.
 
     haproxy_default_options:
@@ -81,13 +81,13 @@ This role can also specify multiple frontends using the `haproxy_frontends` vari
           - 'acl letsencrypt-acl path_beg /.well-known/acme-challenge/'
           - 'reqadd X-Forwarded-Proto:\ https'
           - 'use_backend letsencrypt-backend if letsencrypt-acl'
-      
+
 When using `haproxy_frontends` all `haproxy_frontend_*` variables are ignored.
 
 ### Specifying multiple backends
 
 Likewise, you can also specify multiple backends using `haproxy_backends`:
-      
+
     haproxy_backends:
       - name: 'habackend'
         mode: 'http'
@@ -100,7 +100,7 @@ Likewise, you can also specify multiple backends using `haproxy_backends`:
         servers:
           - name: 'letsencrypt'
             address: '127.0.0.1:54321'  
-        
+
 When using `haproxy_backends` all `haproxy_backend_*` variables are ignored.
 
 ### Other variables
@@ -116,7 +116,7 @@ None.
     - hosts: balancer
       sudo: yes
       roles:
-        - { role: geerlingguy.haproxy }
+        - { role: socketwench.haproxy }
 
 ## License
 
@@ -124,4 +124,4 @@ MIT / BSD
 
 ## Author Information
 
-This role was created in 2015 by [Jeff Geerling](https://www.jeffgeerling.com/), author of [Ansible for DevOps](https://www.ansiblefordevops.com/).
+This role was originally created in 2015 by [Jeff Geerling](https://www.jeffgeerling.com/), and forked by [socketwench](https://deninet.com/).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,58 @@ A list of backend servers (name and address) to which HAProxy will distribute re
     haproxy_global_vars:
       - 'ssl-default-bind-ciphers ABCD+KLMJ:...'
       - 'ssl-default-bind-options no-sslv3'
+      
+A list of default options to use.
+
+    haproxy_default_options:
+      - 'httplog'
+      - 'dontlognull'
+
+### Specifying multiple frontends
+
+This role can also specify multiple frontends using the `haproxy_frontends` variable:
+
+    haproxy_frontends:
+      - name: 'hafrontend'
+        bind_address: '*'
+        bind_port: '80'
+        mode: 'http'
+        backend_name: 'habackend'
+        vars:
+          - 'reqadd X-Forwarded-Proto:\ http'
+      - name: 'hafrontend_ssl'
+        mode: 'http'
+        bind_address: '*'
+        bind_port: '443'
+        bind_cert_path: '/path/to/my/cert.pem'
+        backend_name: 'habackend'
+        vars:
+          - 'acl letsencrypt-acl path_beg /.well-known/acme-challenge/'
+          - 'reqadd X-Forwarded-Proto:\ https'
+          - 'use_backend letsencrypt-backend if letsencrypt-acl'
+      
+When using `haproxy_frontends` all `haproxy_frontend_*` variables are ignored.
+
+### Specifying multiple backends
+
+Likewise, you can also specify multiple backends using `haproxy_backends`:
+      
+    haproxy_backends:
+      - name: 'habackend'
+        mode: 'http'
+        servers:
+          - name: 'app1'
+            address: '123.123.123.123:80'
+            cookie: yes
+            check: yes
+      - name: 'letsencrypt-backend'
+        servers:
+          - name: 'letsencrypt'
+            address: '127.0.0.1:54321'  
+        
+When using `haproxy_backends` all `haproxy_backend_*` variables are ignored.
+
+### Other variables
 
 A list of extra global variables to add to the global configuration section inside `haproxy.cfg`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,18 @@
 ---
+# Global settings
 haproxy_socket: /var/lib/haproxy/stats
 haproxy_chroot: /var/lib/haproxy
 haproxy_user: haproxy
 haproxy_group: haproxy
+haproxy_run_as_daemon: true
+
+# Extra global vars (see README for example usage).
+haproxy_global_vars: []
+
+# Default options.
+haproxy_default_options:
+  - 'httplog'
+  - 'dontlognull'
 
 # Frontend settings.
 haproxy_frontend_name: 'hafrontend'
@@ -45,11 +55,3 @@ haproxy_backends:
       - 'forwardfor'
     cookie: 'SERVERID insert indirect'
     servers: '{{ haproxy_backend_servers }}'
-
-# Extra global vars (see README for example usage).
-haproxy_global_vars: []
-
-# Default options.
-haproxy_default_options:
-  - 'httplog'
-  - 'dontlognull'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ haproxy_backend_httpchk: 'HEAD / HTTP/1.1\r\nHost:localhost'
 haproxy_backend_servers: []
 # - name: app1
 #   address: 192.168.0.1:80
+#   port: 80
 #   cookie: Yes
 #   check: Yes
 # - name: app2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,7 @@ haproxy_backends:
     mode: '{{ haproxy_backend_mode }}'
     balance_method: '{{ haproxy_backend_balance_method }}'
     options:
-      - 'httpchk: {{ haproxy_backend_httpchk }}'
+      - 'httpchk {{ haproxy_backend_httpchk }}'
       - 'forwardfor'
     cookie: 'SERVERID insert indirect'
     servers: '{{ haproxy_backend_servers }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,8 +20,35 @@ haproxy_backend_httpchk: 'HEAD / HTTP/1.1\r\nHost:localhost'
 haproxy_backend_servers: []
 # - name: app1
 #   address: 192.168.0.1:80
+#   cookie: Yes
+#   check: Yes
 # - name: app2
 #   address: 192.168.0.2:80
 
+# Multiple frontends.
+haproxy_frontends:
+  - name: '{{ haproxy_frontend_name }}'
+    bind_address: '{{ haproxy_frontend_bind_address }}'
+    bind_port: '{{ haproxy_frontend_port }}'
+    mode: '{{ haproxy_frontend_mode }}'
+    backend_name: '{{ haproxy_backend_name }}'
+    vars: []
+
+# Multiple backends.
+haproxy_backends:
+  - name: '{{ haproxy_backend_name }}'
+    mode: '{{ haproxy_backend_mode }}'
+    balance_method: '{{ haproxy_backend_balance_method }}'
+    options:
+      - 'httpchk: {{ haproxy_backend_httpchk }}'
+      - 'forwardfor'
+    cookie: 'SERVERID insert indirect'
+    servers: '{{ haproxy_backend_servers }}'
+
 # Extra global vars (see README for example usage).
 haproxy_global_vars: []
+
+# Default options.
+haproxy_default_options:
+  - 'httplog'
+  - 'dontlognull'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ dependencies: []
 galaxy_info:
   role_name: haproxy
   author: socketwench
-  description: HAProxy installation and configuration.
+  description: A fork of geerlingguy.haproxy supporting multiple frontends, backends, and TLS.
   license: "license (BSD, MIT)"
   min_ansible_version: 2.2
   platforms:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,9 +2,9 @@
 dependencies: []
 
 galaxy_info:
-  author: geerlingguy
+  role_name: haproxy
+  author: socketwench
   description: HAProxy installation and configuration.
-  company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
   min_ansible_version: 2.2
   platforms:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -19,4 +19,4 @@
       when: ansible_os_family == 'Debian'
 
   roles:
-    - role: geerlingguy.haproxy
+    - role: socketwench.haproxy

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -11,7 +11,8 @@
 
     haproxy_backend_servers:
       - name: app1
-        address: 127.0.0.1:8080
+        address: 127.0.0.1
+        port: '8080'
 
   pre_tasks:
     - name: Update apt cache.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,10 +16,6 @@
   changed_when: false
   check_mode: false
 
-- name: Set HAProxy version.
-  set_fact:
-    haproxy_version: "{{ '1.5' if '1.5.' in haproxy_version_result.stdout else '1.4' }}"
-
 - name: Copy HAProxy configuration in place.
   template:
     src: haproxy.cfg.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,7 @@
     dest: /etc/haproxy/haproxy.cfg
     mode: 0644
     validate: haproxy -f %s -c -q
+    backup: yes
   notify: restart haproxy
 
 - name: Ensure HAProxy is started and enabled on boot.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
     dest: /etc/haproxy/haproxy.cfg
     mode: 0644
     validate: haproxy -f %s -c -q
-    backup: yes
+    backup: true
   notify: restart haproxy
 
 - name: Ensure HAProxy is started and enabled on boot.

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -35,7 +35,7 @@ defaults
 
 {% for _frontend in haproxy_frontends %}
 frontend {{ _frontend.name }}
-    bind {{ _frontend.bind_address }}:{{ _frontend.bind_port }} {% if _frontend.bind_cert_path | default(false) %}ssl cert {{ _frontend.bind_cert_path }}{% endif %}
+    bind {{ _frontend.bind_address }}:{{ _frontend.bind_port }} {% if _frontend.bind_cert_path | default(false) %}ssl cert {{ _frontend.bind_cert_path }} {% endif %}
     mode {{ _frontend.mode }}
     default_backend {{ _frontend.backend_name }}
 {% for _frontend_var in (_frontend.vars | default([])) %}
@@ -58,7 +58,7 @@ backend {{ _backend.name }}
     cookie {{ _backend.cookie }}
 {% endif %}
 {% for _backend_server in _backend.servers %}
-    server {{ _backend_server.name }} {{ _backend_server.address }} {% if _backend_server.cookie | default(false) %}cookie{% endif %} {% if _backend_server.check | default(false) %}{{ _backend_server.name }} check{% endif %}
+    server {{ _backend_server.name }} {{ _backend_server.address }} {% if _backend_server.cookie | default(false) %}cookie{% endif %} {% if _backend_server.check | default(false) %}{{ _backend_server.name }} check {% endif %}
 {% endfor %}
 
 {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -1,10 +1,10 @@
 global
   log /dev/log  local0
   log /dev/log  local1 notice
-{% if haproxy_socket != '' %}
+{% if haproxy_socket | default(false) %}
   stats socket {{ haproxy_socket }} level admin
 {% endif %}
-{% if haproxy_chroot != '' %}
+{% if haproxy_chroot | default(false) %}
   chroot {{ haproxy_chroot }}
 {% endif %}
   user {{ haproxy_user }}
@@ -35,7 +35,7 @@ defaults
 
 {% for _frontend in haproxy_frontends %}
 frontend {{ _frontend.name }}
-    bind {{ _frontend.bind_address }}:{{ _frontend.bind_port }} {% if _frontend.bind_cert_path | default(false) %}ssl cert {{ _frontend.bind_cert_path }}{% endif %}{{''}}
+    bind {{ _frontend.bind_address }}:{{ _frontend.bind_port }} {% if _frontend.bind_cert_path | default(false) %}ssl crt {{ _frontend.bind_cert_path }}{% endif %}{{''}}
     mode {{ _frontend.mode }}
     default_backend {{ _frontend.backend_name }}
 {% for _frontend_var in (_frontend.vars | default([])) %}
@@ -58,7 +58,7 @@ backend {{ _backend.name }}
     cookie {{ _backend.cookie }}
 {% endif %}
 {% for _backend_server in _backend.servers %}
-    server {{ _backend_server.name }} {{ _backend_server.address }} {% if _backend_server.cookie | default(false) %}cookie{% endif %} {% if _backend_server.check | default(false) %}{{ _backend_server.name }} check{% endif %}{{''}}
+    server {{ _backend_server.name }} {{ _backend_server.address }}:{{ _backend_server.port | default('80') }} {{ _backend_server.params | default([]) | join(' ') }}{{''}}
 {% endfor %}
 
 {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -20,15 +20,9 @@ defaults
 {% for _default_option in haproxy_default_options %}
   option  {{ _default_option }}
 {% endfor %}
-{% if haproxy_version == '1.4' %}
-  contimeout 5000
-  clitimeout 50000
-  srvtimeout 50000
-{% else %}
   timeout connect 5000
   timeout client 50000
   timeout server 50000
-{% endif %}
 {% if ansible_os_family == 'Debian' %}
   errorfile 400 /etc/haproxy/errors/400.http
   errorfile 403 /etc/haproxy/errors/403.http
@@ -41,7 +35,7 @@ defaults
 
 {% for _frontend in haproxy_frontends %}
 frontend {{ _frontend.name }}
-    bind {{ _frontend.bind_address }}:{{ _frontend.bind_port }} {% if _frontend.bind_cert_path | default(false) %}ssl cert {{ _frontend.bind_cert_path }}{% endif %} 
+    bind {{ _frontend.bind_address }}:{{ _frontend.bind_port }} {% if _frontend.bind_cert_path | default(false) %}ssl cert {{ _frontend.bind_cert_path }}{% endif %}
     mode {{ _frontend.mode }}
     default_backend {{ _frontend.backend_name }}
 {% for _frontend_var in (_frontend.vars | default([])) %}
@@ -64,7 +58,7 @@ backend {{ _backend.name }}
     cookie {{ _backend.cookie }}
 {% endif %}
 {% for _backend_server in _backend.servers %}
-    server {{ _backend_server.name }} {{ _backend_server.address }} {% if _backend_server.cookie | default(false) %}cookie{% endif %} {% if _backend_server.check | default(false) %}{{ _backend_server.name }} check{% endif %} 
+    server {{ _backend_server.name }} {{ _backend_server.address }} {% if _backend_server.cookie | default(false) %}cookie{% endif %} {% if _backend_server.check | default(false) %}{{ _backend_server.name }} check{% endif %}
 {% endfor %}
 
 {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -35,7 +35,7 @@ defaults
 
 {% for _frontend in haproxy_frontends %}
 frontend {{ _frontend.name }}
-    bind {{ _frontend.bind_address }}:{{ _frontend.bind_port }} {% if _frontend.bind_cert_path | default(false) %}ssl cert {{ _frontend.bind_cert_path }} {% endif %}
+    bind {{ _frontend.bind_address }}:{{ _frontend.bind_port }} {% if _frontend.bind_cert_path | default(false) %}ssl cert {{ _frontend.bind_cert_path }}{% endif %}{{''}}
     mode {{ _frontend.mode }}
     default_backend {{ _frontend.backend_name }}
 {% for _frontend_var in (_frontend.vars | default([])) %}
@@ -58,7 +58,7 @@ backend {{ _backend.name }}
     cookie {{ _backend.cookie }}
 {% endif %}
 {% for _backend_server in _backend.servers %}
-    server {{ _backend_server.name }} {{ _backend_server.address }} {% if _backend_server.cookie | default(false) %}cookie{% endif %} {% if _backend_server.check | default(false) %}{{ _backend_server.name }} check {% endif %}
+    server {{ _backend_server.name }} {{ _backend_server.address }} {% if _backend_server.cookie | default(false) %}cookie{% endif %} {% if _backend_server.check | default(false) %}{{ _backend_server.name }} check{% endif %}{{''}}
 {% endfor %}
 
 {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -1,10 +1,10 @@
 global
   log /dev/log  local0
   log /dev/log  local1 notice
-{% if haproxy_socket | default(false) %}
+{% if haproxy_socket != '' %}
   stats socket {{ haproxy_socket }} level admin
 {% endif %}
-{% if haproxy_chroot | default(false) %}
+{% if haproxy_chroot != '' %}
   chroot {{ haproxy_chroot }}
 {% endif %}
   user {{ haproxy_user }}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -17,16 +17,17 @@ global
 defaults
   log global
   mode  http
-  option  httplog
-  option  dontlognull
+{% for _default_option in haproxy_default_options %}
+  option  {{ _default_option }}
+{% endfor %}
 {% if haproxy_version == '1.4' %}
-        contimeout 5000
-        clitimeout 50000
-        srvtimeout 50000
+  contimeout 5000
+  clitimeout 50000
+  srvtimeout 50000
 {% else %}
-        timeout connect 5000
-        timeout client 50000
-        timeout server 50000
+  timeout connect 5000
+  timeout client 50000
+  timeout server 50000
 {% endif %}
 {% if ansible_os_family == 'Debian' %}
   errorfile 400 /etc/haproxy/errors/400.http
@@ -38,19 +39,32 @@ defaults
   errorfile 504 /etc/haproxy/errors/504.http
 {% endif %}
 
-frontend {{ haproxy_frontend_name }}
-    bind {{ haproxy_frontend_bind_address }}:{{ haproxy_frontend_port }}
-    mode {{ haproxy_frontend_mode }}
-    default_backend {{ haproxy_backend_name }}
+{% for _frontend in haproxy_frontends %}
+frontend {{ _frontend.name }}
+    bind {{ _frontend.bind_address }}:{{ _frontend.bind_port }} {% if _frontend.bind_cert_path | default(false) %}ssl cert {{ _frontend.bind_cert_path }}{% endif %} 
+    mode {{ _frontend.mode }}
+    default_backend {{ _frontend.backend_name }}
+{% for _frontend_var in (_frontend.vars | default([])) %}
+    {{ _frontend_var }}
+{% endfor %}
 
-backend {{ haproxy_backend_name }}
-    mode {{ haproxy_backend_mode }}
-    balance {{ haproxy_backend_balance_method }}
-    option forwardfor
-{% if haproxy_backend_httpchk != '' %}
-    option httpchk {{ haproxy_backend_httpchk }}
+{% endfor %}
+{% for _backend in haproxy_backends %}
+backend {{ _backend.name }}
+{% if _backend.mode | default(false) %}
+    mode {{ _backend.mode }}
 {% endif %}
-    cookie SERVERID insert indirect
-{% for backend in haproxy_backend_servers %}
-    server {{ backend.name }} {{ backend.address }} cookie {{ backend.name }} check
+{% if _backend.balance_method | default(false) %}
+    balance {{ _backend.balance_method }}
+{% endif %}
+{% for _option in (_backend.options | default([])) %}
+    option {{ _option }}
+{% endfor %}
+{% if _backend.cookie | default(false) %}
+    cookie {{ _backend.cookie }}
+{% endif %}
+{% for _backend_server in _backend.servers %}
+    server {{ _backend_server.name }} {{ _backend_server.address }} {% if _backend_server.cookie | default(false) %}cookie{% endif %} {% if _backend_server.check | default(false) %}{{ _backend_server.name }} check{% endif %} 
+{% endfor %}
+
 {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -9,7 +9,9 @@ global
 {% endif %}
   user {{ haproxy_user }}
   group {{ haproxy_group }}
+{% if haproxy_run_as_daemon | default(true) %}
   daemon
+{% endif %}
 {% for global_var in haproxy_global_vars %}
   {{ global_var }}
 {% endfor %}


### PR DESCRIPTION
This introduces some additional variables to make the definition of the HAProxy  configuration more flexible. Multiple frontends and backends can now be specified, and more configuration items can be modified. 

The role remains backwards compatible with existing variable definitions. 