### PR TITLE
Update version parsing to work on Ubuntu 22.04

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Set HAProxy version.
   set_fact:
-    haproxy_version: '{{ haproxy_version_result.stdout_lines[0] | regex_replace("^HA-Proxy version ([0-9]\.[0-9]).*$", "\1") }}'
+    haproxy_version: '{{ haproxy_version_result.stdout_lines[0] | regex_replace("^HA-?Proxy version ([0-9]\.[0-9]).*$", "\1") }}'
 
 - name: Copy HAProxy configuration in place.
   template:


### PR DESCRIPTION
Fixes #50 

I saw the same thing as #50 on my Ubuntu 22.04 machines, namely, "HAProxy" has no dash in the version string. Making the dash optional in the regex allows the deployment to continue for me, and should continue to work for versions with dashes in the name.
