### PR TITLE
Allow to override the default haproxy.cfg.j2 template

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ HAProxy default timeout configurations.
 
 A list of extra global variables to add to the global configuration section inside `haproxy.cfg`.
 
+## Not happy with the packaged haproxy.cfg.j2 template? Make your own !
+
+The haproxy.cfg.j2 template packaged with this role may not allow you to make all needed configurations.
+Allowing to set every posisble haproxy.cfg in there.
+
+If the default template does not suit your needs, you can replace it with yours. What you need to do:
+* create a `templates` directory at the same level as your playbook
+* create a `templates\haproxy.cfg.j2` file (just choose a different name from the default template)
+* in your playbook set the var `haproxy_template: haproxy.cfg.j2`
+
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,5 @@ haproxy_global_vars: []
 haproxy_connect_timeout: 5000
 haproxy_client_timeout: 50000
 haproxy_server_timeout: 50000
+
+haproxy_template: "haproxy.cfg.j2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Copy HAProxy configuration in place.
   template:
-    src: haproxy.cfg.j2
+    src: '{{ haproxy_template }}'
     dest: /etc/haproxy/haproxy.cfg
     mode: 0644
     validate: haproxy -f %s -c -q


### PR DESCRIPTION
* This change does not change the default role's behaviour and allows user to override the default provided template with their own.