### PR TITLE
Replace command module with package_facts module and use full FQDN

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,14 +11,12 @@
   when: ansible_os_family == 'Debian'
 
 - name: Get HAProxy version.
-  command: haproxy -v
-  register: haproxy_version_result
-  changed_when: false
-  check_mode: false
+  ansible.builtin.package_facts:
+    manager: auto
 
 - name: Set HAProxy version.
-  set_fact:
-    haproxy_version: '{{ haproxy_version_result.stdout_lines[0] | regex_replace("^HA-?Proxy version (\d+(\.\d+)*).*$", "\1") }}'
+  ansible.builtin.set_fact:
+    haproxy_version: "{{ ansible_facts.packages['haproxy']['version'] }"
 
 - name: Copy HAProxy configuration in place.
   template:


### PR DESCRIPTION
- Switching to the package_facts module improves idempotency and reliability by gathering package information without directly invoking system commands.
- Using the full FQDN ensures accuracy and consistency in hostname resolution across different environments.