### PR TITLE
Bring more options to the default configuration template

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ haproxy_group: haproxy
 The user and group under which HAProxy should run. Only change this if you know what you're doing!
 
 ```yaml
+haproxy_ca_base: /etc/ssl/certs
+haproxy_crt_base: /etc/ssl/private
+```
+
+Assigns a default directory to fetch SSL CA certificates and SSL certificates.
+
+```yaml
+haproxy_default_log_format: ''
+haproxy_default_options:
+  - 'option  httplog'
+  - 'option  dontlognull'
+```
+
+HAProxy default configuration directives.
+
+```yaml
 haproxy_frontend_name: 'hafrontend'
 haproxy_frontend_bind_address: '*'
 haproxy_frontend_port: 80
@@ -47,6 +63,8 @@ haproxy_backend_name: 'habackend'
 haproxy_backend_mode: 'http'
 haproxy_backend_balance_method: 'roundrobin'
 haproxy_backend_httpchk: 'HEAD / HTTP/1.1\r\nHost:localhost'
+haproxy_backend_cookie_insert: true
+haproxy_backend_default_server: ''
 ```
 
 HAProxy backend configuration directives.
@@ -68,6 +86,15 @@ haproxy_server_timeout: 50000
 ```
 
 HAProxy default timeout configurations.
+
+```yaml
+haproxy_prometheus_metrics: false
+haproxy_prometheus_metrics_bind_address: '*'
+haproxy_prometheus_metrics_port: 8405
+haproxy_prometheus_metrics_path: /metrics
+```
+
+HAProxy prometheus-exporter configuration directives.
 
 ```yaml
 haproxy_global_vars:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,9 @@ haproxy_chroot: /var/lib/haproxy
 haproxy_user: haproxy
 haproxy_group: haproxy
 
+haproxy_ca_base: /etc/ssl/certs
+haproxy_crt_base: /etc/ssl/private
+
 # Frontend settings.
 haproxy_frontend_name: 'hafrontend'
 haproxy_frontend_bind_address: '*'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ haproxy_ca_base: /etc/ssl/certs
 haproxy_crt_base: /etc/ssl/private
 
 # Default settings.
+haproxy_default_log_format: ''
 haproxy_default_options:
   - 'option  httplog'
   - 'option  dontlognull'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,7 +25,7 @@ haproxy_backend_name: 'habackend'
 haproxy_backend_mode: 'http'
 haproxy_backend_balance_method: 'roundrobin'
 haproxy_backend_httpchk: 'HEAD / HTTP/1.1\r\nHost:localhost'
-haproxy_backend_cookie_instert: true
+haproxy_backend_cookie_insert: true
 haproxy_backend_default_server: ''
 
 # List of backend servers.
@@ -48,5 +48,3 @@ haproxy_prometheus_metrics: false
 haproxy_prometheus_metrics_bind_address: '*'
 haproxy_prometheus_metrics_port: 8405
 haproxy_prometheus_metrics_path: /metrics
-
-haproxy_template: "haproxy.cfg.j2"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,4 +43,10 @@ haproxy_connect_timeout: 5000
 haproxy_client_timeout: 50000
 haproxy_server_timeout: 50000
 
+# HAProxy prometheus setup
+haproxy_prometheus_metrics: false
+haproxy_prometheus_metrics_bind_address: '*'
+haproxy_prometheus_metrics_port: 8405
+haproxy_prometheus_metrics_path: /metrics
+
 haproxy_template: "haproxy.cfg.j2"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,7 @@ haproxy_backend_mode: 'http'
 haproxy_backend_balance_method: 'roundrobin'
 haproxy_backend_httpchk: 'HEAD / HTTP/1.1\r\nHost:localhost'
 haproxy_backend_cookie_instert: true
+haproxy_backend_default_server: ''
 
 # List of backend servers.
 haproxy_backend_servers: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,11 @@ haproxy_group: haproxy
 haproxy_ca_base: /etc/ssl/certs
 haproxy_crt_base: /etc/ssl/private
 
+# Default settings.
+haproxy_default_options:
+  - 'option  httplog'
+  - 'option  dontlognull'
+
 # Frontend settings.
 haproxy_frontend_name: 'hafrontend'
 haproxy_frontend_bind_address: '*'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 haproxy_socket: /var/lib/haproxy/stats
+haproxy_socket_mode: '660'
 haproxy_chroot: /var/lib/haproxy
 haproxy_user: haproxy
 haproxy_group: haproxy

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,3 +48,5 @@ haproxy_prometheus_metrics: false
 haproxy_prometheus_metrics_bind_address: '*'
 haproxy_prometheus_metrics_port: 8405
 haproxy_prometheus_metrics_path: /metrics
+
+haproxy_template: "haproxy.cfg.j2"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,7 @@ haproxy_backend_name: 'habackend'
 haproxy_backend_mode: 'http'
 haproxy_backend_balance_method: 'roundrobin'
 haproxy_backend_httpchk: 'HEAD / HTTP/1.1\r\nHost:localhost'
+haproxy_backend_cookie_instert: true
 
 # List of backend servers.
 haproxy_backend_servers: []

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -2,7 +2,7 @@ global
   log /dev/log  local0
   log /dev/log  local1 notice
 {% if haproxy_socket != '' %}
-  stats socket {{ haproxy_socket }} level admin
+  stats socket {{ haproxy_socket }} mode {{ haproxy_socket_mode }} level admin
 {% endif %}
 {% if haproxy_chroot != '' %}
   chroot {{ haproxy_chroot }}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -19,6 +19,9 @@ global
 
 defaults
   log global
+{% if haproxy_default_log_format != '' %}
+  log-format {{ haproxy_default_log_format }}
+{% endif %}
   mode  http
 {% for default_option in haproxy_default_options %}
   {{ default_option }}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -59,14 +59,14 @@ backend {{ haproxy_backend_name }}
 {% if haproxy_backend_httpchk != '' %}
     option httpchk {{ haproxy_backend_httpchk }}
 {% endif %}
-{% if haproxy_backend_cookie_instert %}
+{% if haproxy_backend_cookie_insert %}
     cookie SERVERID insert indirect
 {% endif %}
 {% if haproxy_backend_default_server != '' %}
     default-server {{ haproxy_backend_default_server }}
 {% endif %}
 {% for backend in haproxy_backend_servers %}
-    server {{ backend.name }} {{ backend.address }} {% if haproxy_backend_cookie_instert %}cookie {{ backend.name }}{% endif %} check
+    server {{ backend.name }} {{ backend.address }} {% if haproxy_backend_cookie_insert %}cookie {{ backend.name }}{% endif %} check
 {% endfor %}
 
 {% if haproxy_prometheus_metrics %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -57,6 +57,9 @@ backend {{ haproxy_backend_name }}
 {% if haproxy_backend_cookie_instert %}
     cookie SERVERID insert indirect
 {% endif %}
+{% if haproxy_backend_default_server != '' %}
+    default-server {{ haproxy_backend_default_server }}
+{% endif %}
 {% for backend in haproxy_backend_servers %}
-    server {{ backend.name }} {{ backend.address }} {% if haproxy_backend_cookie_instert %}cookie{% endif %} {{ backend.name }} check
+    server {{ backend.name }} {{ backend.address }} {% if haproxy_backend_cookie_instert %}cookie {{ backend.name }}{% endif %} check
 {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -20,8 +20,9 @@ global
 defaults
   log global
   mode  http
-  option  httplog
-  option  dontlognull
+{% for default_option in haproxy_default_options %}
+  {{ default_option }}
+{% endfor %}
 {% if haproxy_version is version('1.4', '<=') %}
         contimeout {{ haproxy_connect_timeout }}
         clitimeout {{ haproxy_client_timeout }}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -10,6 +10,9 @@ global
   user {{ haproxy_user }}
   group {{ haproxy_group }}
   daemon
+
+  ca-base {{ haproxy_ca_base }}
+  crt-base {{ haproxy_crt_base }}
 {% for global_var in haproxy_global_vars %}
   {{ global_var }}
 {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -27,13 +27,13 @@ defaults
   {{ default_option }}
 {% endfor %}
 {% if haproxy_version is version('1.4', '<=') %}
-        contimeout {{ haproxy_connect_timeout }}
-        clitimeout {{ haproxy_client_timeout }}
-        srvtimeout {{ haproxy_server_timeout }}
+  contimeout {{ haproxy_connect_timeout }}
+  clitimeout {{ haproxy_client_timeout }}
+  srvtimeout {{ haproxy_server_timeout }}
 {% else %}
-        timeout connect {{ haproxy_connect_timeout }}
-        timeout client {{ haproxy_client_timeout }}
-        timeout server {{ haproxy_server_timeout }}
+  timeout connect {{ haproxy_connect_timeout }}
+  timeout client {{ haproxy_client_timeout }}
+  timeout server {{ haproxy_server_timeout }}
 {% endif %}
 {% if ansible_os_family == 'Debian' %}
   errorfile 400 /etc/haproxy/errors/400.http
@@ -53,7 +53,9 @@ frontend {{ haproxy_frontend_name }}
 backend {{ haproxy_backend_name }}
     mode {{ haproxy_backend_mode }}
     balance {{ haproxy_backend_balance_method }}
+{% if haproxy_backend_mode == 'http' %}
     option forwardfor
+{% endif %}
 {% if haproxy_backend_httpchk != '' %}
     option httpchk {{ haproxy_backend_httpchk }}
 {% endif %}
@@ -66,3 +68,12 @@ backend {{ haproxy_backend_name }}
 {% for backend in haproxy_backend_servers %}
     server {{ backend.name }} {{ backend.address }} {% if haproxy_backend_cookie_instert %}cookie {{ backend.name }}{% endif %} check
 {% endfor %}
+
+{% if haproxy_prometheus_metrics %}
+frontend prometheus
+  bind {{ haproxy_prometheus_metrics_bind_address }}:{{ haproxy_prometheus_metrics_port }}
+  mode http
+  stats enable
+  http-request use-service prometheus-exporter if { path {{ haproxy_prometheus_metrics_path }} }
+  no log
+{% endif %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -54,7 +54,9 @@ backend {{ haproxy_backend_name }}
 {% if haproxy_backend_httpchk != '' %}
     option httpchk {{ haproxy_backend_httpchk }}
 {% endif %}
+{% if haproxy_backend_cookie_instert %}
     cookie SERVERID insert indirect
+{% endif %}
 {% for backend in haproxy_backend_servers %}
-    server {{ backend.name }} {{ backend.address }} cookie {{ backend.name }} check
+    server {{ backend.name }} {{ backend.address }} {% if haproxy_backend_cookie_instert %}cookie{% endif %} {{ backend.name }} check
 {% endfor %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,1 @@
+haproxy_template: "haproxy.cfg.j2"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,1 +1,0 @@
-haproxy_template: "haproxy.cfg.j2"


### PR DESCRIPTION
Hello! I propose to add some new changes to give users more control over configuration template:

1. Add directives for [ca-base](https://docs.haproxy.org/2.6/configuration.html#3.1-ca-base) and [crt-base](https://docs.haproxy.org/2.6/configuration.html#3.1-crt-base)
2. Allow to define custom default [log-format](https://docs.haproxy.org/2.6/configuration.html#log-format)
3. Allow to define custom list of default options, preserving the one that was used in this role as default
4. Make cookie insertion optional
5. Allow to define [default-server](https://docs.haproxy.org/2.6/configuration.html#4.2-default-server) configuration for backend
6. Add support for prometheus metrics exporter that is built-in in HAProxy now

I have tested this setup with HAProxy version
```
HAProxy version 2.6.12-1+deb12u3 2025/10/03
```
Which is installed now by default on Debian 12.